### PR TITLE
Add ignore build step script

### DIFF
--- a/ignore-build-step.sh
+++ b/ignore-build-step.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ "$VERCEL_ENV" == "production" ]] ; then
+  # Proceed with the build
+  exit 1;
+else
+  # Don't build
+  exit 0;
+fi


### PR DESCRIPTION
Currently, Vercel builds every branch in a preview deployment. Generally that's great, but since I'm preparing this repo to be public I think it would be a bit inconvenient. Also, in order to make the app work for every new deployment the corresponding URL should be added into the OAuth urls.

This PR creates a `ignore-build-step.sh` that only builds when targeting production. This is configured in Vercel under the `Settings -> Ignored Build Step`.