### PR TITLE
Add preview

### DIFF
--- a/app/components/labeled-markdown.tsx
+++ b/app/components/labeled-markdown.tsx
@@ -1,0 +1,72 @@
+import React, { PropsWithoutRef, useState } from "react"
+import { useFormContext } from "react-hook-form"
+import Markdown from "app/components/markdown"
+
+export interface LabeledMarkdownProps extends PropsWithoutRef<JSX.IntrinsicElements["textarea"]> {
+  name: string
+  label: string
+  outerProps?: PropsWithoutRef<JSX.IntrinsicElements["div"]>
+}
+
+export const LabeledMarkDownField = React.forwardRef<HTMLTextAreaElement, LabeledMarkdownProps>(
+  ({ label, outerProps, ...props }, ref) => {
+    const [preview, setPreview] = useState(false)
+    const togglePreview = () => setPreview(!preview)
+
+    const {
+      register,
+      formState: { isSubmitting },
+      errors,
+      watch,
+    } = useFormContext()
+
+    const watchField = watch(props.name)
+
+    const error = Array.isArray(errors[props.name])
+      ? errors[props.name].join(", ")
+      : errors[props.name]?.message || errors[props.name]
+
+    return (
+      <div className="mt-8 relative" {...outerProps}>
+        <label>
+          <div className={`text-base ${preview && "invisible"}`}>{label}</div>
+
+          <div className="flex">
+            <textarea
+              className={`border-gray-default border rounded outline-none pl-4 pt-2 pb-2 pr-4 mt-1 w-full h-80 ${
+                error && "border-red-500"
+              } ${preview ? "hidden" : "block"}`}
+              disabled={isSubmitting}
+              {...props}
+              ref={register}
+            />
+            <Markdown
+              onDoubleClick={togglePreview}
+              className={`border-transparent border rounded p-2 ${!preview ? "hidden" : "block"}`}
+            >
+              {watchField}
+            </Markdown>
+          </div>
+
+          <div className="absolute -top-0 right-2 mr-1">
+            <button
+              className="flex justify-center items-center rounded-full h-8 w-8 border-none outline-none focus:outline-none text-blue-default opacity-30 hover:opacity-100 transition-all text-xs"
+              type="button"
+              onClick={togglePreview}
+            >
+              {preview ? "Edit" : "Preview"}
+            </button>
+          </div>
+        </label>
+
+        {error && (
+          <div role="alert" style={{ color: "red" }}>
+            {error}
+          </div>
+        )}
+      </div>
+    )
+  }
+)
+
+export default LabeledMarkDownField

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -1,0 +1,55 @@
+import MDownComponent, { MarkdownToJSX } from "markdown-to-jsx"
+
+export default function Markdown({
+  children,
+  options,
+  className = "",
+  ...rest
+}: {
+  children: string
+  options?: MarkdownToJSX.Options
+  className?: string
+} & JSX.IntrinsicElements["div"]) {
+  return (
+    <div className={`${className}`} {...rest}>
+      <MDownComponent
+        options={{
+          forceWrapper: true,
+          overrides: {
+            a: {
+              props: {
+                className: "leading-relaxed text-blue-default hover:underline",
+              },
+            },
+            p: {
+              props: {
+                className: "text-light mb-4",
+              },
+            },
+            h1: {
+              props: {
+                className: "text-base font-medium mb-2 mt-8",
+              },
+            },
+            li: {
+              props: {
+                className: "list-disc list-inside",
+              },
+            },
+            code: {
+              props: {
+                className: "font-mono px-1 text-sm",
+                style: {
+                  color: "#FF7E32",
+                },
+              },
+            },
+          },
+          ...options,
+        }}
+      >
+        {children}
+      </MDownComponent>
+    </div>
+  )
+}

--- a/app/messages/pages/messages/[id].tsx
+++ b/app/messages/pages/messages/[id].tsx
@@ -1,5 +1,4 @@
 import { BlitzPage, Link, useMutation, useParam, useQuery, useSession } from "blitz"
-import Markdown from "markdown-to-jsx"
 import getMessage from "app/messages/queries/getMessage"
 import { Suspense, useEffect } from "react"
 import SlackChannel, { SlackChannelFallback } from "app/messages/components/slack-channel"
@@ -8,6 +7,7 @@ import BottomBar from "app/components/bottom-bar"
 import LinkButton from "app/components/LinkButton"
 import createMessageView from "app/messageViews/mutations/createMessageView"
 import AvatarList from "app/components/avatar-list"
+import Markdown from "app/components/markdown"
 
 const ShowMessage: BlitzPage = () => {
   const id = useParam("id", "string")
@@ -49,43 +49,7 @@ const ShowMessage: BlitzPage = () => {
       </div>
 
       <h1 className="text-4xl font-medium mb-6">{message.title}</h1>
-      <Markdown
-        options={{
-          forceWrapper: true,
-          overrides: {
-            a: {
-              props: {
-                className: "leading-relaxed text-blue-default hover:underline",
-              },
-            },
-            p: {
-              props: {
-                className: "text-light mb-4",
-              },
-            },
-            h1: {
-              props: {
-                className: "text-base font-medium mb-2 mt-8",
-              },
-            },
-            li: {
-              props: {
-                className: "list-disc list-inside",
-              },
-            },
-            code: {
-              props: {
-                className: "font-mono px-1 text-sm",
-                style: {
-                  color: "#FF7E32",
-                },
-              },
-            },
-          },
-        }}
-      >
-        {message.body}
-      </Markdown>
+      <Markdown>{message.body}</Markdown>
       <BottomBar>
         <div>
           <Suspense fallback="Loading reactions">

--- a/app/messages/pages/messages/[id]/edit.tsx
+++ b/app/messages/pages/messages/[id]/edit.tsx
@@ -1,6 +1,5 @@
 import Form, { FORM_ERROR } from "app/components/Form"
 import LabeledTextField from "app/components/LabeledTextField"
-import LabeledTextArea from "app/components/LabeledTextArea"
 import { UpdateMessageInput } from "app/messages/validations"
 import { BlitzPage, useMutation, useParam, useQuery, useRouter } from "blitz"
 import updateMessage from "app/messages/mutations/updateMessage"

--- a/app/messages/pages/messages/[id]/edit.tsx
+++ b/app/messages/pages/messages/[id]/edit.tsx
@@ -5,6 +5,7 @@ import { UpdateMessageInput } from "app/messages/validations"
 import { BlitzPage, useMutation, useParam, useQuery, useRouter } from "blitz"
 import updateMessage from "app/messages/mutations/updateMessage"
 import getMessage from "app/messages/queries/getMessage"
+import LabeledMarkDownField from "app/components/labeled-markdown"
 
 const EditMessage: BlitzPage = () => {
   const router = useRouter()
@@ -30,7 +31,7 @@ const EditMessage: BlitzPage = () => {
         }}
       >
         <LabeledTextField name="title" label="Title" placeholder="Title" />
-        <LabeledTextArea name="body" label="Body" placeholder="Body" />
+        <LabeledMarkDownField name="body" label="Body" placeholder="Body" />
       </Form>
     </div>
   )

--- a/app/messages/pages/messages/new.tsx
+++ b/app/messages/pages/messages/new.tsx
@@ -1,11 +1,11 @@
 import Form, { FORM_ERROR } from "app/components/Form"
 import LabeledTextField from "app/components/LabeledTextField"
-import LabeledTextArea from "app/components/LabeledTextArea"
 import createMessage from "app/messages/mutations/createMessage"
 import { CreateMessageInput } from "app/messages/validations"
 import { BlitzPage, useMutation, useRouter, useRouterQuery } from "blitz"
 import { Suspense } from "react"
 import SlackChannelPicker from "app/messages/components/slack-channel-picker"
+import LabeledMarkDownField from "app/components/labeled-markdown"
 
 const NewMessage: BlitzPage = () => {
   const router = useRouter()
@@ -40,7 +40,7 @@ const NewMessage: BlitzPage = () => {
         }}
       >
         <LabeledTextField name="title" label="Title" placeholder="Title" />
-        <LabeledTextArea name="body" label="Body" placeholder="Body" />
+        <LabeledMarkDownField name="body" label="Body" placeholder="Body" />
       </Form>
     </div>
   )


### PR DESCRIPTION
This PR adds the ability to toggle between a textarea and a markdown preview when creating and editing a message. Useful to test how your message will look like when publishing.