### PR TITLE
Query users only when app is installed

### DIFF
--- a/app/api/slack/inbox.ts
+++ b/app/api/slack/inbox.ts
@@ -51,7 +51,7 @@ export default CronJob(
   "0 10 * * 0-5", // Every day of the week at 10am
   async (_job) => {
     const web = new WebClient(process.env.SLACK_TOKEN)
-    const users = await db.user.findMany()
+    const users = await db.user.findMany({ where: { isInstalled: true } })
 
     for (let user of users) {
       // Gets the already seen messages


### PR DESCRIPTION
This PR changes the way users are queried, instead of all users only query for the ones that installed the app. This prevents scope errors on the `slack/inbox` cron.

This is a bandaid for a much complex problem that's spawning one fan out job for each user so we gracefully let this discrete fan out jobs fail. Right now if one fails everything fails.